### PR TITLE
The DoWork method should only call Task.Start for tasks that have only been created.

### DIFF
--- a/src/WebBackgrounder.UnitTests/JobHostFacts.cs
+++ b/src/WebBackgrounder.UnitTests/JobHostFacts.cs
@@ -58,6 +58,19 @@ namespace WebBackgrounder.UnitTests
 
                 Assert.Equal("work", exception.ParamName);
             }
+
+            [Fact]
+            public void DoesNotCallStartIfWorkIsAlreadyScheduledOrCompleted()
+            {
+                var tcs = new TaskCompletionSource<object>();
+                tcs.SetResult(null);
+
+                var task = tcs.Task;
+
+                var host = new JobHost();
+
+                Assert.DoesNotThrow(() => host.DoWork(task));
+            }
         }
     }
 }

--- a/src/WebBackgrounder/JobHost.cs
+++ b/src/WebBackgrounder/JobHost.cs
@@ -35,7 +35,12 @@ namespace WebBackgrounder
                 {
                     return;
                 }
-                work.Start();
+
+                if (work.Status == TaskStatus.Created)
+                {
+                    work.Start();
+                }
+
                 // Need to hold the lock until the task completes.
                 // Later on, we should take advantage of the fact that the work is represented 
                 // by a task. Instead of locking, we could simply have the Stop method cancel 


### PR DESCRIPTION
`Task.Start()` will throw an `InvalidOperationException` if the task has already been scheduled to run, is running, or has already completed. Therefore, it should only be called if the task is not in any of those states.
