### PR TITLE
[WIP] Add support for cancellation

### DIFF
--- a/src/WebBackgrounder.EntityFramework/WorkItemCleanupJob.cs
+++ b/src/WebBackgrounder.EntityFramework/WorkItemCleanupJob.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace WebBackgrounder.Jobs
@@ -29,7 +30,7 @@ namespace WebBackgrounder.Jobs
             private set;
         }
 
-        public override Task Execute()
+        public override Task Execute(CancellationToken cancellationToken)
         {
             return new Task(() =>
             {

--- a/src/WebBackgrounder.UnitTests/JobManagerFacts.cs
+++ b/src/WebBackgrounder.UnitTests/JobManagerFacts.cs
@@ -30,7 +30,7 @@ namespace WebBackgrounder.UnitTests
                 job.Setup(j => j.Interval).Returns(TimeSpan.FromMilliseconds(1));
                 var jobs = new[] { job.Object };
                 var coordinator = new Mock<IJobCoordinator>();
-                coordinator.Setup(c => c.GetWork(job.Object)).Returns(new Task(() => jobDoneEvent.Set()));
+                coordinator.Setup(c => c.GetWork(job.Object)).Returns(new Task(() => jobDoneEvent.Set()).ToJob());
 
                 using (var manager = new JobManager(jobs, coordinator.Object))
                 {
@@ -51,8 +51,8 @@ namespace WebBackgrounder.UnitTests
                 shorterJob.Setup(j => j.Interval).Returns(TimeSpan.FromMilliseconds(3));
                 var jobs = new[] { longerJob.Object, shorterJob.Object };
                 var coordinator = new Mock<IJobCoordinator>();
-                coordinator.Setup(c => c.GetWork(shorterJob.Object)).Returns((Task)null).Callback(() => { completed.Enqueue("shortJob"); shorterJobDoneEvent.Set(); });
-                coordinator.Setup(c => c.GetWork(longerJob.Object)).Returns((Task)null).Callback(() => { completed.Enqueue("longJob"); longerJobDoneEvent.Set(); });
+                coordinator.Setup(c => c.GetWork(shorterJob.Object)).Returns((IJob)null).Callback(() => { completed.Enqueue("shortJob"); shorterJobDoneEvent.Set(); });
+                coordinator.Setup(c => c.GetWork(longerJob.Object)).Returns((IJob)null).Callback(() => { completed.Enqueue("longJob"); longerJobDoneEvent.Set(); });
 
                 using (var manager = new JobManager(jobs, coordinator.Object))
                 {
@@ -77,8 +77,8 @@ namespace WebBackgrounder.UnitTests
                 var jobs = new[] { jobNoTask.Object, secondJob.Object };
                 var firstJobCompleteEvent = new ManualResetEvent(false);
                 var coordinator = new Mock<IJobCoordinator>();
-                coordinator.Setup(c => c.GetWork(jobNoTask.Object)).Returns((Task)null);
-                coordinator.Setup(c => c.GetWork(secondJob.Object)).Returns((Task)null).Callback(() => firstJobCompleteEvent.Set());
+                coordinator.Setup(c => c.GetWork(jobNoTask.Object)).Returns((IJob)null);
+                coordinator.Setup(c => c.GetWork(secondJob.Object)).Returns((IJob)null).Callback(() => firstJobCompleteEvent.Set());
 
                 bool failed = false;
 
@@ -103,7 +103,7 @@ namespace WebBackgrounder.UnitTests
                 var firstJobCompleteEvent = new ManualResetEvent(false);
                 var coordinator = new Mock<IJobCoordinator>();
                 coordinator.Setup(c => c.GetWork(jobNoTask.Object)).Throws<Exception>();
-                coordinator.Setup(c => c.GetWork(secondJob.Object)).Returns((Task)null).Callback(() => firstJobCompleteEvent.Set());
+                coordinator.Setup(c => c.GetWork(secondJob.Object)).Returns((IJob)null).Callback(() => firstJobCompleteEvent.Set());
 
                 using (var manager = new JobManager(jobs, coordinator.Object))
                 {
@@ -124,7 +124,7 @@ namespace WebBackgrounder.UnitTests
                 var firstJobCompleteEvent = new ManualResetEvent(false);
                 var coordinator = new Mock<IJobCoordinator>();
                 coordinator.Setup(c => c.GetWork(jobNoTask.Object)).Throws<Exception>();
-                coordinator.Setup(c => c.GetWork(secondJob.Object)).Returns((Task)null).Callback(() => firstJobCompleteEvent.Set());
+                coordinator.Setup(c => c.GetWork(secondJob.Object)).Returns((IJob)null).Callback(() => firstJobCompleteEvent.Set());
 
                 using (var manager = new JobManager(jobs, coordinator.Object))
                 {

--- a/src/WebBackgrounder.UnitTests/SchedulerFacts.cs
+++ b/src/WebBackgrounder.UnitTests/SchedulerFacts.cs
@@ -45,12 +45,12 @@ namespace WebBackgrounder.UnitTests
                 var scheduler = new Scheduler(jobs, dates.Dequeue);
 
                 var firstSchedule = scheduler.Next();
-                firstSchedule.Job.Execute();
+                firstSchedule.Job.Execute(CancellationToken.None);
                 firstSchedule.SetRunComplete();
                 var secondSchedule = scheduler.Next();
                 secondSchedule.SetRunComplete();
                 var thirdSchedule = scheduler.Next();
-                
+
                 thirdSchedule.SetRunComplete();
                 var fourthSchedule = scheduler.Next();
                 fourthSchedule.SetRunComplete();
@@ -80,7 +80,7 @@ namespace WebBackgrounder.UnitTests
                 var scheduler = new Scheduler(jobs, dates.Dequeue);
 
                 var firstSchedule = scheduler.Next();
-                firstSchedule.Job.Execute();
+                firstSchedule.Job.Execute(CancellationToken.None);
                 firstSchedule.SetRunComplete();
                 var secondSchedule = scheduler.Next();
                 secondSchedule.SetRunComplete();
@@ -105,7 +105,7 @@ namespace WebBackgrounder.UnitTests
 
                 public int Id { get; private set; }
 
-                public override Task Execute()
+                public override Task Execute(CancellationToken cancellationToken)
                 {
                     return new Task(() => Thread.Sleep(1));
                 }

--- a/src/WebBackgrounder.UnitTests/WebFarmJobCoordinatorFacts.cs
+++ b/src/WebBackgrounder.UnitTests/WebFarmJobCoordinatorFacts.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Moq;
 using Xunit;
@@ -86,7 +87,7 @@ namespace WebBackgrounder.UnitTests
             {
                 var job = new Mock<IJob>();
                 job.Setup(j => j.Name).Returns("job-name");
-                job.Setup(j => j.Execute()).Throws(new InvalidOperationException("Test Exception"));
+                job.Setup(j => j.Execute(It.IsAny<CancellationToken>())).Throws(new InvalidOperationException("Test Exception"));
                 var repository = new Mock<IWorkItemRepository>();
                 repository.Setup(r => r.GetLastWorkItem(job.Object)).Returns((IWorkItem)null);
                 repository.Setup(r => r.RunInTransaction(It.IsAny<Action>())).Callback<Action>(a => a());
@@ -129,7 +130,7 @@ namespace WebBackgrounder.UnitTests
                 set;
             }
 
-            public Task Execute()
+            public Task Execute(CancellationToken cancellationToken)
             {
                 return null;
             }

--- a/src/WebBackgrounder.UnitTests/WorkItemCleanupJobFacts.cs
+++ b/src/WebBackgrounder.UnitTests/WorkItemCleanupJobFacts.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading;
 using Moq;
 using WebBackgrounder.Jobs;
 using Xunit;
@@ -24,7 +25,7 @@ namespace WebBackgrounder.UnitTests
                     new WorkItem {Id = 105 }
                 });
                 var job = new WorkItemCleanupJob(TimeSpan.FromMilliseconds(1), TimeSpan.FromDays(2), context.Object);
-                var task = job.Execute();
+                var task = job.Execute(CancellationToken.None);
                 task.Start();
                 task.Wait();
 
@@ -43,7 +44,7 @@ namespace WebBackgrounder.UnitTests
                 context.Object.WorkItems = new InMemoryDbSet<WorkItem> { new WorkItem(), new WorkItem() };
                 var job = new WorkItemCleanupJob(TimeSpan.FromSeconds(1), TimeSpan.FromDays(1), context.Object);
 
-                job.Execute();
+                job.Execute(CancellationToken.None);
             }
         }
     }

--- a/src/WebBackgrounder/DelegatingJob.cs
+++ b/src/WebBackgrounder/DelegatingJob.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WebBackgrounder
+{
+    public class DelegatingJob : IJob
+    {
+        private Func<Task> _taskThunk;
+
+        private DelegatingJob(Func<Task> taskThunk)
+        {
+            _taskThunk = taskThunk;
+        }
+
+        public DelegatingJob(IJob job, Func<Task> taskThunk)
+        {
+            Name = job.Name;
+            Interval = job.Interval;
+            Timeout = job.Timeout;
+            _taskThunk = taskThunk;
+        }
+
+        // Used in unit tests.
+        public static IJob Create(Func<Task> taskThunk)
+        {
+            return new DelegatingJob(taskThunk);
+        }
+
+        // Used in unit tests.
+        public static IJob Create(Task task)
+        {
+            return new DelegatingJob(() => task);
+        }
+
+        public string Name { get; set; }
+
+        public Task Execute()
+        {
+            return _taskThunk();
+        }
+
+        public TimeSpan Interval { get; set; }
+
+        public TimeSpan Timeout { get; set; }
+    }
+}

--- a/src/WebBackgrounder/DelegatingJob.cs
+++ b/src/WebBackgrounder/DelegatingJob.cs
@@ -36,6 +36,11 @@ namespace WebBackgrounder
             return new DelegatingJob((_) => task);
         }
 
+        public static IJob Create(Func<CancellationToken, Task> taskThunk)
+        {
+            return new DelegatingJob(taskThunk);
+        }
+
         public string Name { get; set; }
 
         public Task Execute(CancellationToken cancellationToken)

--- a/src/WebBackgrounder/IJob.cs
+++ b/src/WebBackgrounder/IJob.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace WebBackgrounder
@@ -10,7 +11,7 @@ namespace WebBackgrounder
         /// </summary>
         string Name { get; }
 
-        Task Execute();
+        Task Execute(CancellationToken cancellationToken);
 
         TimeSpan Interval { get; }
 

--- a/src/WebBackgrounder/IJobCoordinator.cs
+++ b/src/WebBackgrounder/IJobCoordinator.cs
@@ -6,10 +6,10 @@ namespace WebBackgrounder
     public interface IJobCoordinator : IDisposable
     {
         /// <summary>
-        /// Coordinates the work to be done and returns a task that wraps 
+        /// Coordinates the work to be done and returns another job that wraps 
         /// the work as well as the coordination of that work.
         /// </summary>
         /// <param name="job"></param>
-        Task GetWork(IJob job);
+        IJob GetWork(IJob job);
     }
 }

--- a/src/WebBackgrounder/IJobHost.cs
+++ b/src/WebBackgrounder/IJobHost.cs
@@ -9,6 +9,6 @@ namespace WebBackgrounder
     /// </summary>
     public interface IJobHost
     {
-        void DoWork(Task work);
+        void DoWork(IJob work);
     }
 }

--- a/src/WebBackgrounder/Job.cs
+++ b/src/WebBackgrounder/Job.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace WebBackgrounder
@@ -20,7 +21,7 @@ namespace WebBackgrounder
             private set;
         }
 
-        public abstract Task Execute();
+        public abstract Task Execute(CancellationToken cancellationToken);
 
         public TimeSpan Interval
         {

--- a/src/WebBackgrounder/JobHost.cs
+++ b/src/WebBackgrounder/JobHost.cs
@@ -23,7 +23,7 @@ namespace WebBackgrounder
             HostingEnvironment.UnregisterObject(this);
         }
 
-        public void DoWork(Task work)
+        public void DoWork(IJob work)
         {
             if (work == null)
             {
@@ -36,16 +36,18 @@ namespace WebBackgrounder
                     return;
                 }
 
-                if (work.Status == TaskStatus.Created)
+                var task = work.Execute();
+
+                if (task.Status == TaskStatus.Created)
                 {
-                    work.Start();
+                    task.Start();
                 }
 
                 // Need to hold the lock until the task completes.
                 // Later on, we should take advantage of the fact that the work is represented 
                 // by a task. Instead of locking, we could simply have the Stop method cancel 
                 // any pending tasks.
-                work.Wait();
+                task.Wait();
             }
         }
     }

--- a/src/WebBackgrounder/JobHost.cs
+++ b/src/WebBackgrounder/JobHost.cs
@@ -47,11 +47,18 @@ namespace WebBackgrounder
                     task.Start();
                 }
 
-                // Need to hold the lock until the task completes.
-                // Later on, we should take advantage of the fact that the work is represented 
-                // by a task. Instead of locking, we could simply have the Stop method cancel 
-                // any pending tasks.
-                task.Wait();
+                try
+                {
+                    // Wait() rethrows exceptions (if any) wrapped in an AggregateException.
+                    task.Wait();
+                }
+                catch (AggregateException ae)
+                {
+                    if (ae.Flatten().InnerException as OperationCanceledException == null)
+                    {
+                        throw; // Rethrow if the real exception wasn't OperationCanceledException.
+                    }
+                }
             }
         }
     }

--- a/src/WebBackgrounder/SingleServerJobCoordinator.cs
+++ b/src/WebBackgrounder/SingleServerJobCoordinator.cs
@@ -4,9 +4,9 @@ namespace WebBackgrounder
 {
     public class SingleServerJobCoordinator : IJobCoordinator
     {
-        public Task GetWork(IJob job)
+        public IJob GetWork(IJob job)
         {
-            return job.Execute();
+            return job;
         }
 
         public void Dispose()

--- a/src/WebBackgrounder/WebBackgrounder.csproj
+++ b/src/WebBackgrounder/WebBackgrounder.csproj
@@ -44,6 +44,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DelegatingJob.cs" />
     <Compile Include="IJobCoordinator.cs" />
     <Compile Include="IJob.cs" />
     <Compile Include="IJobHost.cs" />

--- a/src/WebBackgrounder/WebFarmJobCoordinator.cs
+++ b/src/WebBackgrounder/WebFarmJobCoordinator.cs
@@ -35,12 +35,12 @@ namespace WebBackgrounder
                 return null;
             }
 
-            return new DelegatingJob(job, () =>
+            return new DelegatingJob(job, (cancellationToken) =>
             {
                 Task task = null;
                 try
                 {
-                    task = job.Execute();
+                    task = job.Execute(cancellationToken);
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
I've tried a lot doing this in a backwards compatible way but things got really **awkward** so I decided to shift things a little bit and it seems to be the only way to support cancellation. I was using this for myself at first but decided to attempt a contribution anyway (though this breaks compatibility).

There are a couple of things I changed semantically. One thing I thought was really strange is the task returned by Job.Execute, because you get used to tasks returned by methods being hot. This is not -or rather should not be- the case with jobs for them to work will with the job manager and the coordinator.